### PR TITLE
Add a simple experiments runner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ the Blackbox server and, many hours later, you will have a `combos` file (which
 is the list of pairs needed to regenerate the source files) as well as the
 Java source in a `src_files` directory. **The latter must never be
 redistributed.** However, the `combos` file is safe is redistribution.
+
+
+## Run the experiments
+
+`cd runner && ./build.sh` will build and run the experiments. Output files will
+be `runner/*.out`.

--- a/runner/.gitignore
+++ b/runner/.gitignore
@@ -1,0 +1,4 @@
+grammars/
+lrpar/
+src_files/
+*.csv

--- a/runner/build.sh
+++ b/runner/build.sh
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+set -e
+
+LRPARV=7193be36
+GRAMMARSV=fb1c6550
+
+if [ ! -d lrpar ]; then
+    git clone https://github.com/softdevteam/lrpar
+    cd lrpar
+    git checkout ${LRPARV}
+    patch -p0 < ../print_budget.patch
+    cargo build --release
+    cd ..
+fi
+
+if [ ! -d lrpar_rev ]; then
+    git clone https://github.com/softdevteam/lrpar lrpar_rev
+    cd lrpar_rev
+    git checkout ${LRPARV}
+    patch -p0 < ../print_budget.patch
+    patch -p0 < ../rev_rank.patch
+    cargo build --release
+    cd ..
+fi
+
+if [ ! -d grammars ]; then
+    git clone https://github.com/softdevteam/grammars/
+    cd grammars && git checkout ${GRAMMARSV}
+    cd ..
+fi
+
+./run.py src_files lrpar/target/release/lrpar cpctplus grammars/java7/java.l grammars/java7/java.y cpctplus.csv
+./run.py src_files lrpar/target/release/lrpar cpctplusdyndist grammars/java7/java.l grammars/java7/java.y cpctplusdyndist.csv
+./run.py src_files lrpar/target/release/lrpar mf grammars/java7/java.l grammars/java7/java.y mf.csv
+./run.py src_files lrpar_rev/target/release/lrpar mf grammars/java7/java.l grammars/java7/java.y mf_rev.csv

--- a/runner/print_budget.patch
+++ b/runner/print_budget.patch
@@ -1,0 +1,37 @@
+diff --git src/lib/parser.rs src/lib/parser.rs
+index dcb12bc..ab5ebda 100644
+--- src/lib/parser.rs
++++ src/lib/parser.rs
+@@ -163,6 +163,7 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
+                 Some(Action::Accept) => {
+                     debug_assert_eq!(la_tidx, self.grm.eof_term_idx());
+                     debug_assert_eq!(tstack.len(), 1);
++                    println!("recovery budget {:?}", recovery_budget.as_secs() as f64 + recovery_budget.subsec_nanos() as f64 * 1e-9);
+                     return true;
+                 },
+                 None => {
+@@ -201,6 +202,7 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
+                     errors.push(ParseError{state_idx: st, lexeme_idx: la_idx,
+                                            lexeme: la_lexeme, repairs: repairs});
+                     if !keep_going {
++                        println!("recovery budget {:?}", recovery_budget.as_secs() as f64 + recovery_budget.subsec_nanos() as f64 * 1e-9);
+                         return false;
+                     }
+                     la_idx = new_la_idx;
+diff --git src/main.rs src/main.rs
+index bba4e8b..0596c15 100644
+--- src/main.rs
++++ src/main.rs
+@@ -185,10 +185,12 @@ fn main() {
+     match parse_rcvry::<u16, _>(recoverykind, &grm, &term_cost, &sgraph, &stable, &lexemes) {
+         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
+         Err((o_pt, errs)) => {
++            /*
+             match o_pt {
+                 Some(pt) => println!("{}", pt.pp(&grm, &input)),
+                 None     => println!("Unable to repair input sufficiently to produce parse tree.\n")
+             }
++            */
+             for e in errs {
+                 let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
+                 if e.repairs().is_empty() {

--- a/runner/rev_rank.patch
+++ b/runner/rev_rank.patch
@@ -1,0 +1,12 @@
+diff --git src/lib/mf.rs src/lib/mf.rs
+index 7163543..1c61636 100644
+--- src/lib/mf.rs
++++ src/lib/mf.rs
+@@ -516,6 +516,7 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
+                                 .cmp(&y.2.len()))
+                .then_with(|| x.2.cmp(&y.2))
+         });
++        cnds.reverse();
+ 
+         cnds.into_iter()
+             .map(|x| x.2)

--- a/runner/run.py
+++ b/runner/run.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python2.7
+
+import os, re, sys
+from subprocess import Popen
+from tempfile import TemporaryFile
+
+RE_BUDGET = re.compile("recovery budget ([0-9.]+)")
+RE_RECOVERY_POINTS = re.compile("^Error at line", re.MULTILINE)
+BUDGET = 0.5
+
+src_files, binary, recoverer, yaccp, lexp, outp = sys.argv[1:7]
+
+assert not os.path.exists(outp)
+
+times = []
+failures = 0
+i = 0
+with open(outp, "w") as outf:
+    for l in os.listdir(src_files):
+        i += 1
+        if i % 10 == 0:
+            sys.stdout.write(".")
+            sys.stdout.flush()
+        p = os.path.join(src_files, l)
+        with TemporaryFile() as tmpf:
+            lrpar = Popen([binary, "-r", recoverer, yaccp, lexp, p], stdout=tmpf)
+            lrpar.wait()
+            tmpf.seek(0, os.SEEK_SET)
+            output = tmpf.read()
+            num_recovery_points = len(list(RE_RECOVERY_POINTS.finditer(output)))
+            m = RE_BUDGET.match(output)
+            remaining = float(m.group(1))
+            spent = BUDGET - remaining
+            if "No repairs found" in output:
+                failures += 1
+                f = "0"
+            else:
+                f = "1"
+            # CSV fields (in order:
+            #   bench name,
+            #   time spent recovering (secs)
+            #   succeeded recovering (0: failed, 1: succeeded)
+            #   num repair points found
+            outf.write("%s, %.10f, %s, %s\n" % (l, spent, f, num_recovery_points))
+            times.append(spent)
+
+print
+print "Average:", sum(times) / len(times)
+times.sort()
+print "Median:", times[len(times) / 2]
+print "#Failed to repair: %d (%.3f%%)" % (failures, (float(failures) / len(times)) * 100.0)


### PR DESCRIPTION
This runs 4 experiments: cpctplus; cpctplusdyndist; mf; and "reverse mf". The latter inverts the ranking order of repair sequences i.e. it guarantees to always pick from the worst (and not the best) repair sequences.

In order for the runner to work, we have to slightly patch lrpar so that it prints out how much time it spent in recovery. That then allows the runner to do its work and record output in CSV output files.

I'm sure this will need a bit of tweaking later, but it at least does the basics.