### PR TITLE
Predictable build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ redistributed.** However, the `combos` file is safe to redistribute.
 
 ## Run the experiments
 
-`cd runner && ./build.sh` will build and run the experiments. Output files will
-be `runner/*.out`. Output PDF and TeX files can be produced with `cd runner &&
+`cd runner && ./build.sh` will build the experiments. If files called
+`runner/lrpar_Cargo.lock` or `runner/lrpar_rev_Cargo.lock` are present, they
+will be used as `Cargo.lock` files for `mf` and `mfref`.
+
+`cd runner && ./run.sh` will run the experiments. You need to have a directory
+`src_files` with all the relevant source files *inside* the `runner/` directory.
+Output files will be called `runner/*.csv`.
+
+Human friendly PDF and TeX files can be produced with `cd runner &&
 ./process.py`.

--- a/runner/build.sh
+++ b/runner/build.sh
@@ -8,6 +8,9 @@ GRAMMARSV=fb1c6550
 if [ ! -d lrpar ]; then
     git clone https://github.com/softdevteam/lrpar
     cd lrpar
+    if [ ! -f ../lrpar_Cargo.lock ]; then
+        cp ../lrpar_Cargo.lock Cargo.lock
+    fi
     git checkout ${LRPARV}
     patch -p0 < ../print_budget.patch
     cargo build --release
@@ -17,6 +20,9 @@ fi
 if [ ! -d lrpar_rev ]; then
     git clone https://github.com/softdevteam/lrpar lrpar_rev
     cd lrpar_rev
+    if [ ! -f ../lrpar_rev_Cargo.lock ]; then
+        cp ../lrpar_rev_Cargo.lock Cargo.lock
+    fi
     git checkout ${LRPARV}
     patch -p0 < ../print_budget.patch
     patch -p0 < ../rev_rank.patch

--- a/runner/build.sh
+++ b/runner/build.sh
@@ -35,7 +35,3 @@ if [ ! -d grammars ]; then
     cd grammars && git checkout ${GRAMMARSV}
     cd ..
 fi
-
-./run.py src_files lrpar/target/release/lrpar cpctplus grammars/java7/java.l grammars/java7/java.y cpctplus.csv
-./run.py src_files lrpar/target/release/lrpar mf grammars/java7/java.l grammars/java7/java.y mf.csv
-./run.py src_files lrpar_rev/target/release/lrpar mf grammars/java7/java.l grammars/java7/java.y mf_rev.csv

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+set -e
+
+./run.py src_files lrpar/target/release/lrpar cpctplus grammars/java7/java.l grammars/java7/java.y cpctplus.csv
+./run.py src_files lrpar/target/release/lrpar mf grammars/java7/java.l grammars/java7/java.y mf.csv
+./run.py src_files lrpar_rev/target/release/lrpar mf grammars/java7/java.l grammars/java7/java.y mf_rev.csv


### PR DESCRIPTION
Make the experiment building a bit nicer. First, provide a way to lock down the Rust build with `Cargo.lock` files. Second, separate out building the experiment from running it.