### PR TITLE
Rewrite the results processor: generate confidence intervals; calculate costs

### DIFF
--- a/runner/.gitignore
+++ b/runner/.gitignore
@@ -4,3 +4,4 @@ src_files/
 *.csv
 experimentstats.tex
 table.tex
+*.pdf

--- a/runner/build.sh
+++ b/runner/build.sh
@@ -12,7 +12,7 @@ if [ ! -d lrpar ]; then
         cp ../lrpar_Cargo.lock Cargo.lock
     fi
     git checkout ${LRPARV}
-    patch -p0 < ../print_budget.patch
+    patch -p1 < ../print_budget.patch
     cargo build --release
     cd ..
 fi
@@ -24,7 +24,7 @@ if [ ! -d lrpar_rev ]; then
         cp ../lrpar_rev_Cargo.lock Cargo.lock
     fi
     git checkout ${LRPARV}
-    patch -p0 < ../print_budget.patch
+    patch -p1 < ../print_budget.patch
     patch -p0 < ../rev_rank.patch
     cargo build --release
     cd ..
@@ -34,4 +34,10 @@ if [ ! -d grammars ]; then
     git clone https://github.com/softdevteam/grammars/
     cd grammars && git checkout ${GRAMMARSV}
     cd ..
+fi
+
+if [ ! -d pykalibera ]; then
+    git clone https://github.com/softdevteam/libkalibera/
+    mv libkalibera/python/pykalibera pykalibera
+    rm -rf libkalibera
 fi

--- a/runner/print_budget.patch
+++ b/runner/print_budget.patch
@@ -1,7 +1,26 @@
-diff --git src/lib/parser.rs src/lib/parser.rs
-index dcb12bc..ab5ebda 100644
---- src/lib/parser.rs
-+++ src/lib/parser.rs
+diff --git a/src/lib/astar.rs b/src/lib/astar.rs
+index c59fe84..43578c4 100644
+--- a/src/lib/astar.rs
++++ b/src/lib/astar.rs
+@@ -135,6 +135,7 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
+         }
+     }
+ 
++    println!("repair cost {}", c);
+     scs_nodes
+ }
+ 
+@@ -211,5 +212,6 @@ pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
+         }
+     }
+ 
++    println!("repair cost {}", c);
+     scs_nodes
+ }
+diff --git a/src/lib/parser.rs b/src/lib/parser.rs
+index 3aaefac..0d9e041 100644
+--- a/src/lib/parser.rs
++++ b/src/lib/parser.rs
 @@ -163,6 +163,7 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
                  Some(Action::Accept) => {
                      debug_assert_eq!(la_tidx, self.grm.eof_term_idx());
@@ -18,10 +37,10 @@ index dcb12bc..ab5ebda 100644
                          return false;
                      }
                      la_idx = new_la_idx;
-diff --git src/main.rs src/main.rs
-index bba4e8b..0596c15 100644
---- src/main.rs
-+++ src/main.rs
+diff --git a/src/main.rs b/src/main.rs
+index 0c71440..387710f 100644
+--- a/src/main.rs
++++ b/src/main.rs
 @@ -185,10 +185,12 @@ fn main() {
      match parse_rcvry::<u16, _>(recoverykind, &grm, &term_cost, &sgraph, &stable, &lexemes) {
          Ok(pt) => println!("{}", pt.pp(&grm, &input)),

--- a/runner/process.py
+++ b/runner/process.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python2.7
 
-import os
+import math, random, os, sys
 from os import listdir, stat
 from decimal import Decimal
 
@@ -10,54 +10,165 @@ matplotlib.rcParams['text.usetex'] = True
 matplotlib.rcParams['text.latex.preamble'] = [r'\usepackage[cm]{sfmath}']
 matplotlib.rcParams['font.family'] = 'sans-serif'
 matplotlib.rcParams['font.sans-serif'] = 'cm'
+matplotlib.rcParams.update({'errorbar.capsize': 2})
 from matplotlib.ticker import ScalarFormatter
+import matplotlib.patches as mpatches
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
+from numpy import histogram
+
+from pykalibera.data import confidence_slice
 
 SRC_FILES_DIR = "src_files"
+BOOTSTRAP = 10000
+HISTOGRAM_BINS = 75
+ERROR_LOCS_HISTOGRAM_BINS = 50
+MAX_RECOVERY_TIME = 0.5
+
+class PExec:
+    def __init__(self,
+                 name,
+                 run_num,
+                 recovery_time,
+                 succeeded,
+                 costs):
+        self.name = name
+        self.run_num = run_num
+        self.recovery_time = recovery_time
+        self.succeeded = succeeded
+        self.costs = costs
 
 class Results:
     def __init__(self,
                  latex_name,
-                 rows,
-                 num_error_locs,
-                 failure_rate,
-                 mean_time,
-                 median_time):
+                 pexecs,
+                 num_runs):
         self.latex_name = latex_name
-        self.rows = rows
-        self.num_error_locs = num_error_locs
-        self.failure_rate = failure_rate
-        self.mean_time = mean_time
-        self.median_time = median_time
+        benches = {}
+        for p in pexecs:
+            if p.name not in benches:
+                benches[p.name] = []
+            benches[p.name].append(p)
+        self.pexecs = list(benches.values())
+        self.num_runs = num_runs
+
+        sys.stdout.write("%s: recovery_times..." % latex_name)
+        sys.stdout.flush()
+        self.recovery_time_mean_ci = confidence_slice(self.bootstrap_recovery_means(), "0.99")
+        self.recovery_time_median_ci = confidence_slice(self.bootstrap_recovery_medians(), "0.99")
+        sys.stdout.write(" failure rates...")
+        sys.stdout.flush()
+        self.failure_rate_ci = confidence_slice(self.bootstrap_failure_rates(), "0.99")
+        sys.stdout.write(" error locations...")
+        sys.stdout.flush()
+        self.error_locs_ci = confidence_slice(self.bootstrap_error_locs(), "0.99")
+        sys.stdout.write(" costs...")
+        sys.stdout.flush()
+        self.costs_ci = confidence_slice(self.bootstrap_costs(), "0.99")
+        print
+
+    def bootstrap_recovery_means(self):
+        out = []
+        for i in range(BOOTSTRAP):
+            means = []
+            for pexecs in self.pexecs:
+                pexec = random.choice(pexecs)
+                means.append(pexec.recovery_time)
+            out.append(mean(means))
+        return out
+
+    def bootstrap_recovery_medians(self):
+        out = []
+        for i in range(BOOTSTRAP):
+            means = []
+            for pexecs in self.pexecs:
+                pexec = random.choice(pexecs)
+                means.append(pexec.recovery_time)
+            out.append(median(means))
+        return out
+
+    def bootstrap_failure_rates(self):
+        out = []
+        for i in range(BOOTSTRAP):
+            failures = 0
+            for pexecs in self.pexecs:
+                pexec = random.choice(pexecs)
+                if not pexec.succeeded:
+                    failures += 1
+            out.append((float(failures) / float(len(self.pexecs))) * 100.0)
+        return out
+
+    def bootstrap_error_locs(self):
+        out = []
+        for i in range(BOOTSTRAP):
+            error_locs = 0
+            for pexecs in self.pexecs:
+                pexec = random.choice(pexecs)
+                error_locs += len(pexec.costs)
+            out.append(error_locs)
+        return out
+
+    def bootstrap_costs(self):
+        out = []
+        for i in range(BOOTSTRAP):
+            costs = []
+            for pexecs in self.pexecs:
+                pexec = random.choice(pexecs)
+                if pexec.succeeded:
+                    costs.extend(pexec.costs)
+            if len(costs) > 0:
+                out.append(mean(costs))
+        return out
+
+def confidence_ratio_recovery_means(x, y):
+    xmeans = x.bootstrap_recovery_means()
+    ymeans = y.bootstrap_recovery_means()
+    out = []
+    for a, b in zip(xmeans, ymeans):
+        out.append(float(a / b) * 100.0)
+    return confidence_slice(out, "0.99")
+
+def confidence_ratio_error_locs(x, y):
+    xmeans = x.bootstrap_error_locs()
+    ymeans = y.bootstrap_error_locs()
+    out = []
+    for a, b in zip(xmeans, ymeans):
+        out.append((float(a - b) / float(b)) * 100.0)
+    return confidence_slice(out, "0.99")
+
+def mean(l):
+    return math.fsum(l) / float(len(l))
+
+def median(l):
+    l.sort()
+    if len(l) % 2 == 0:
+        return mean([l[len(l) // 2 - 1], l[len(l) // 2]])
+    else:
+        return l[len(l) // 2]
 
 def process(latex_name, p):
-    d = []
+    pexecs = []
     num_error_locs = 0
     num_success = 0
+    max_run_num = 0
     with open(p) as f:
         for l in f.readlines():
             l = l.strip()
             if len(l) == 0:
                 continue
-            s = l.split(", ")
-            r = [s[0],
-                 Decimal(s[1]),
-                 True if s[2] == "1" else False,
-                 int(s[3])]
-            d.append(r)
-            num_error_locs += r[3]
-            if r[2]:
-                num_success += 1
+            s = [x.strip() for x in l.split(",")]
+            if s[3] == "1":
+                succeeded = True
+            else:
+                assert s[3] == "0"
+                succeeded = False
+            costs = [int(x) for x in s[4].split(":") if x != ""]
+            pexec = PExec(s[0], int(s[1]), Decimal(s[2]), succeeded, costs)
+            max_run_num = max(max_run_num, pexec.run_num)
+            pexecs.append(pexec)
 
-    failure_rate = (float(len(d) - num_success) / len(d)) * 100.0
-    times = map(lambda x: x[1], d)
-    mean_time = sum(times) / len(d)
-    times.sort()
-    assert(len(d) % 2 == 0)
-    median_time = times[len(d) / 2]
-    return Results(latex_name, d, num_error_locs, failure_rate, mean_time, median_time)
+    return Results(latex_name, pexecs, max_run_num + 1)
 
 def corpus_size():
     num_files = 0
@@ -69,12 +180,27 @@ def corpus_size():
     return num_files, size_bytes
 
 def time_histogram(run, p):
+    bbins = [[] for _ in range(HISTOGRAM_BINS)]
+    bin_width = MAX_RECOVERY_TIME / HISTOGRAM_BINS
+    for _ in range(BOOTSTRAP):
+        d = [float(random.choice(pexecs).recovery_time) for pexecs in run.pexecs]
+        hbins, _ = histogram(d, bins=HISTOGRAM_BINS, range=(0, MAX_RECOVERY_TIME))
+        for i, cnt in enumerate(hbins):
+            bbins[i].append(cnt)
+
+    bins = []
+    errs = []
+    for bbin in bbins:
+        ci = confidence_slice(bbin, "0.99")
+        bins.append(ci.median)
+        errs.append(int(ci.error))
+
     sns.set(style="whitegrid")
     plt.rc('text', usetex=True)
     plt.rc('font', family='sans-serif')
     fig, ax = plt.subplots(figsize=(8, 4))
-    d = map(lambda x: float(x[1]), run.rows)
-    n, bins, patches = ax.hist(d, 75, log=True, color="black", rwidth=.8)
+    plt.bar(range(HISTOGRAM_BINS), bins, yerr=errs, align="center", log=True, color="#777777", \
+            error_kw={"ecolor": "black", "elinewidth": 1, "capthick": 0.5, "capsize": 1})
     ax.set_xlabel('Recovery time (s)')
     ax.set_ylabel('Number of files (log$_{10}$)')
     ax.grid(linewidth=0.25)
@@ -82,72 +208,150 @@ def time_histogram(run, p):
     ax.spines['top'].set_visible(False)
     ax.xaxis.set_ticks_position('bottom')
     ax.yaxis.set_ticks_position('left')
-    plt.xlim(xmin=0, xmax=0.5)
-    plt.ylim(ymin=0, ymax=len(d))
-    ax.set_yticks([20, 200, 2000, 20000, 200000])
+    plt.xlim(xmin=-.2, xmax=HISTOGRAM_BINS)
+    locs = []
+    labs = []
+    for i in range(0, 6):
+        locs.append((HISTOGRAM_BINS / 5) * i - 0.5)
+        labs.append(i / 10.0)
+    plt.xticks(locs, labs)
     formatter = ScalarFormatter()
     formatter.set_scientific(False)
     ax.yaxis.set_major_formatter(formatter)
     plt.savefig(p, format="pdf")
 
-def error_locs_histogram(run1, run2, p):
+def calc_max_error_locs(run):
+    n = 0
+    for pexecs in run.pexecs:
+        for pexec in pexecs:
+            n = max(n, len(pexec.costs))
+    return n
+
+def flat_zip(x, y):
+    assert len(x) == len(y)
+    out = []
+    for z in zip(x, y):
+        out.extend(z)
+    return out
+
+def error_locs_histogram(run1, run2, p, zoom=None):
+    def bins_errs(run, num_bins, max_error_locs):
+        bbins = [[] for _ in range(num_bins)]
+        bin_width = max_error_locs / num_bins
+        for _ in range(BOOTSTRAP):
+            d = [len(random.choice(pexecs).costs) for pexecs in run.pexecs]
+            if zoom is not None:
+                d = filter(lambda x: x <= zoom, d)
+            hbins, _ = histogram(d, bins=num_bins, range=(0, max_error_locs))
+            for i, cnt in enumerate(hbins):
+                bbins[i].append(cnt)
+
+        bins = []
+        errs = []
+        for bbin in bbins:
+            ci = confidence_slice(bbin, "0.99")
+            bins.append(ci.median)
+            errs.append(int(ci.error))
+
+        return bins, errs
+
+    if zoom is None:
+        max_error_locs = max(calc_max_error_locs(run1), calc_max_error_locs(run2))
+    else:
+        max_error_locs = zoom
+    run1_bins, run1_errs = bins_errs(run1, ERROR_LOCS_HISTOGRAM_BINS, max_error_locs)
+    run2_bins, run2_errs = bins_errs(run2, ERROR_LOCS_HISTOGRAM_BINS, max_error_locs)
+
     sns.set(style="whitegrid")
     plt.rc('text', usetex=True)
     plt.rc('font', family='sans-serif')
     fig, ax = plt.subplots(figsize=(8, 4))
-    d1 = map(lambda x: float(x[3]), run1.rows)
-    d2 = map(lambda x: float(x[3]), run2.rows)
-    n, bins, patches = ax.hist([d1, d2], 250, log=True, color=["black", "darkgray"], \
-                               label=[r"\textrm{MF}", r"\textrm{MF}$_{\textrm{rev}}$"], lw=0, rwidth=1)
-    ax.set_xlabel('Number of error locations')
+    barlist = plt.bar(range(ERROR_LOCS_HISTOGRAM_BINS * 2), flat_zip(run1_bins, run2_bins), yerr=flat_zip(run1_errs, run2_errs), \
+            align="center", log=True, color=["black", "red"], \
+            error_kw={"ecolor": "black", "elinewidth": 1, "capthick": 0.5, "capsize": 1})
+    for i in range(0, len(barlist), 2):
+        barlist[i].set_color("#777777")
+        barlist[i + 1].set_color("#BBBBBB")
+    mf_patch = mpatches.Patch(color="#777777", label=r"\textrm{MF}")
+    mfrev_patch = mpatches.Patch(color="#BBBBBB", label=r"\textrm{MF}$_{\textrm{rev}}$")
+    plt.legend(handles=[mf_patch, mfrev_patch])
+    ax.set_xlabel('Recovery error locations')
     ax.set_ylabel('Number of files (log$_{10}$)')
     ax.grid(linewidth=0.25)
     ax.spines['right'].set_visible(False)
     ax.spines['top'].set_visible(False)
     ax.xaxis.set_ticks_position('bottom')
     ax.yaxis.set_ticks_position('left')
-    plt.xlim(xmin=0, xmax=300)
-    plt.ylim(ymin=0, ymax=len(d1))
-    ax.set_yticks([20, 200, 2000, 20000, 200000])
+    plt.xlim(xmin=-.7, xmax=ERROR_LOCS_HISTOGRAM_BINS * 2)
+    locs = []
+    labs = []
+    for i in range(0, 8):
+        locs.append((ERROR_LOCS_HISTOGRAM_BINS / 7) * i * 2 - 0.5)
+        labs.append(int(round((max_error_locs / 7.0) * i)))
+    plt.xticks(locs, labs)
     formatter = ScalarFormatter()
     formatter.set_scientific(False)
     ax.yaxis.set_major_formatter(formatter)
-    plt.legend(loc='upper right')
     plt.savefig(p, format="pdf")
 
 cpctplus = process("\\cpctplus", "cpctplus.csv")
 mf = process("\\mf", "mf.csv")
 mfrev = process("\\mfrev", "mf_rev.csv")
+assert cpctplus.num_runs == mf.num_runs == mfrev.num_runs
 
 with open("experimentstats.tex", "w") as f:
+    f.write(r"\newcommand{\numruns}{\numprint{%s}\xspace}" % str(cpctplus.num_runs))
+    f.write("\n")
+    f.write(r"\newcommand{\numbootstrap}{\numprint{%s}\xspace}" % str(BOOTSTRAP))
+    f.write("\n")
     num_files, size_bytes = corpus_size()
     f.write(r"\newcommand{\corpussize}{\numprint{%s}\xspace}" % str(num_files))
     f.write("\n")
     f.write(r"\newcommand{\corpussizemb}{\numprint{%s}\xspace}" % str(size_bytes / 1024 / 1024))
     f.write("\n")
     for x in [cpctplus, mf, mfrev]:
-        f.write(r"\newcommand{%ssuccessrate}{%.2f\%%\xspace}" % (x.latex_name, 100.0 - x.failure_rate))
+        f.write(r"\newcommand{%ssuccessrate}{%.2f\%%{\footnotesize$\pm$%.2f\%%}\xspace}" % \
+                (x.latex_name, 100.0 - x.failure_rate_ci.median, x.failure_rate_ci.error))
         f.write("\n")
-        f.write(r"\newcommand{%sfailurerate}{%.2f\%%\xspace}" % (x.latex_name, x.failure_rate))
+        f.write(r"\newcommand{%sfailurerate}{%.2f\%%${\footnotesize$\pm$%.2f\%%}\xspace}" % \
+                (x.latex_name, x.failure_rate_ci.median, x.failure_rate_ci.error))
         f.write("\n")
-        f.write(r"\newcommand{%smeantime}{%.5fs\xspace}" % (x.latex_name, x.mean_time))
+        f.write(r"\newcommand{%smeantime}{%.4fs{\footnotesize$\pm$%.4fs}\xspace}" % \
+                (x.latex_name, x.recovery_time_mean_ci.median, x.recovery_time_mean_ci.error))
         f.write("\n")
-        f.write(r"\newcommand{%smediantime}{%.5fs\xspace}" % (x.latex_name, x.median_time))
+        f.write(r"\newcommand{%smediantime}{%.4fs{\footnotesize$\pm$%.4fs}\xspace}" % \
+                (x.latex_name, x.recovery_time_median_ci.median, x.recovery_time_median_ci.error))
         f.write("\n")
-        f.write(r"\newcommand{%serrorlocs}{\numprint{%s}\xspace}" % (x.latex_name, x.num_error_locs))
+        f.write(r"\newcommand{%serrorlocs}{\numprint{%s}{\footnotesize$\pm$\numprint{%s}}\xspace}" % \
+                (x.latex_name, x.error_locs_ci.median, x.error_locs_ci.error))
         f.write("\n")
 
-    mf_cpctplus_ratio = (mf.failure_rate / cpctplus.failure_rate) * 100.0
-    f.write(r"\newcommand{\mfcpctplusfailurerateratio}{%.2f\%%\xspace}" % mf_cpctplus_ratio)
+    mf_cpctplus_ratio_ci = confidence_ratio_recovery_means(mf, cpctplus)
+    f.write(r"\newcommand{\mfcpctplusfailurerateratio}{%.1f\%%{\footnotesize$\pm$%.1f\%%}\xspace}" % \
+            (mf_cpctplus_ratio_ci.median, mf_cpctplus_ratio_ci.error))
     f.write("\n")
 
-    mfrev_mf_ratio = (float(mfrev.num_error_locs - mf.num_error_locs) / mf.num_error_locs) * 100.0
-    f.write(r"\newcommand{\mfreverrorlocsratioovermf}{%.2f\%%\xspace}" % mfrev_mf_ratio)
+    mfrev_mf_ratio_ci = confidence_ratio_error_locs(mfrev, mf)
+    f.write(r"\newcommand{\mfreverrorlocsratioovermf}{%.1f\%%{\footnotesize$\pm$%.2f\%%}\xspace}" % \
+            (mfrev_mf_ratio_ci.median, mfrev_mf_ratio_ci.error))
     f.write("\n")
 
 with open("table.tex", "w") as f:
     for x in [cpctplus, mf, mfrev]:
-        f.write("%s & %.5f & %.5f & %.2f & \\numprint{%d} \\\\\n" % (x.latex_name, x.mean_time, x.median_time, x.failure_rate, x.num_error_locs))
+        f.write("%s & %.4f{\scriptsize$\pm$%.5f} & %.6f{\scriptsize$\pm$%.7f} & %.2f{\scriptsize$\pm$%.3f}& %.2f{\scriptsize$\pm$%.3f} & \\numprint{%d}{\scriptsize$\pm$%s} \\\\\n" % \
+                (x.latex_name, \
+                 x.recovery_time_mean_ci.median, x.recovery_time_mean_ci.error, \
+                 x.recovery_time_median_ci.median, x.recovery_time_median_ci.error, \
+                 x.costs_ci.median, x.costs_ci.error, \
+                 x.failure_rate_ci.median, x.failure_rate_ci.error, \
+                 x.error_locs_ci.median, int(x.error_locs_ci.error)))
 
+sys.stdout.write("MF histogram...")
+sys.stdout.flush()
 time_histogram(mf, "mf_histogram.pdf")
-error_locs_histogram(mf, mfrev, "mf_mfrev_error_locs_histogram.pdf")
+print
+sys.stdout.write("Error locations histogram...")
+sys.stdout.flush()
+error_locs_histogram(mf, mfrev, "mf_mfrev_error_locs_histogram_full.pdf")
+error_locs_histogram(mf, mfrev, "mf_mfrev_error_locs_histogram_zoomed.pdf", zoom=150)
+print

--- a/runner/run.py
+++ b/runner/run.py
@@ -4,9 +4,11 @@ import os, re, sys, time
 from subprocess import Popen
 from tempfile import TemporaryFile
 
-RE_BUDGET = re.compile("recovery budget ([0-9.]+)")
+RE_BUDGET = re.compile("^recovery budget ([0-9.]+)", re.MULTILINE)
+RE_COST = re.compile("^repair cost ([0-9.]+)", re.MULTILINE)
 RE_RECOVERY_POINTS = re.compile("^Error at line", re.MULTILINE)
 BUDGET = 0.5
+PEXECS = 30
 
 src_files, binary, recoverer, yaccp, lexp, outp = sys.argv[1:7]
 
@@ -16,36 +18,45 @@ times = []
 failures = 0
 i = 0
 with open(outp, "w") as outf:
-    for l in os.listdir(src_files):
-        i += 1
-        if i % 100 == 0:
-            sys.stdout.write(".")
-            sys.stdout.flush()
-        if i % 1000 == 0:
-            # Let the machine have a chance to cool down every so often
-            time.sleep(10)
-        p = os.path.join(src_files, l)
-        with TemporaryFile() as tmpf:
-            lrpar = Popen([binary, "-r", recoverer, yaccp, lexp, p], stdout=tmpf)
-            lrpar.wait()
-            tmpf.seek(0, os.SEEK_SET)
-            output = tmpf.read()
-            num_recovery_points = len(list(RE_RECOVERY_POINTS.finditer(output)))
-            m = RE_BUDGET.match(output)
-            remaining = float(m.group(1))
-            spent = BUDGET - remaining
-            if "No repairs found" in output:
-                failures += 1
-                f = "0"
-            else:
-                f = "1"
-            # CSV fields (in order:
-            #   bench name,
-            #   time spent recovering (secs)
-            #   succeeded recovering (0: failed, 1: succeeded)
-            #   num repair points found
-            outf.write("%s, %.10f, %s, %s\n" % (l, spent, f, num_recovery_points))
-            times.append(spent)
+    for j in range(PEXECS):
+        for l in os.listdir(src_files):
+            i += 1
+            if i % 100 == 0:
+                sys.stdout.write(".")
+                sys.stdout.flush()
+            if i % 1000 == 0:
+                # Let the machine have a chance to cool down every so often
+                time.sleep(10)
+            p = os.path.join(src_files, l)
+            with TemporaryFile() as tmpf:
+                lrpar = Popen([binary, "-r", recoverer, yaccp, lexp, p], stdout=tmpf)
+                lrpar.wait()
+                tmpf.seek(0, os.SEEK_SET)
+                output = tmpf.read()
+                m = RE_BUDGET.search(output)
+                remaining = float(m.group(1))
+                spent = BUDGET - remaining
+                if "No repairs found" in output:
+                    failures += 1
+                    f = "0"
+                    costs = ""
+                else:
+                    f = "1"
+                    costs_l = []
+                    for m in RE_COST.finditer(output):
+                        costs_l.append(m.group(1))
+                    assert(len(costs_l) == len(list(RE_RECOVERY_POINTS.finditer(output))))
+                    costs = ":".join(costs_l)
+                # CSV fields, in order:
+                #   bench name,
+                #   run number,
+                #   time spent recovering (secs)
+                #   succeeded recovering (0: failed, 1: succeeded)
+                #   cost of each repair point found (separated by ":" and only
+                #                                    meaningful if succeeded recovering == 1)
+                outf.write("%s, %s, %.10f, %s, %s\n" % (l, j, spent, f, costs))
+                outf.flush()
+                times.append(spent)
 
 print
 print "Average:", sum(times) / len(times)


### PR DESCRIPTION
This is a very big change. We now run each error recovery algorithm on each source file PEXECS (=30) times. When generating results, we then use this (huge!) amount of data to bootstrap and produce 99% confidence intervals (using https://github.com/softdevteam/libkalibera/). As a side bonus, we also now collect the cost of each repair sequence found, which allows us to produce statistics on the mean cost of repair sequences.

I appreciate this isn't a very easy PR to review. I have made `process.py` a bit less hacky internally now, but it's never going to be the prettiest program in the world.

The easiest way to see the effect of this is to build https://github.com/softdevteam/error_recovery_paper/commit/c79450eb3af29c9f68da76a43eb46bdf1570dbd6 from the `warmup_paper` repository: you'll now see that stats in the prose (e.g. in the abstract) have confidence intervals; and the histograms at the end of the paper (Figures 18 and 19) now have error bars.