### PR TITLE
Don't count input skipped because of incomplete error recovery.

### DIFF
--- a/runner/java_parser/src/main.rs
+++ b/runner/java_parser/src/main.rs
@@ -35,7 +35,6 @@ fn main() {
             }
             if pt.is_none() {
                 println!("Parsing did not complete");
-                skipped += lexemes.len() - errs[errs.len() - 1].lexeme_idx();
             }
         }
     }


### PR DESCRIPTION
Previously "skipped input" consisted of input skipped by Delete repairs, as well as input skipped at the end of a file because we couldn't repair it. In retrospect, this second thing has very little relation to the first. What we're really interested in is how many Delete repairs there are, so delete the second thing from out measurement (noting that the second thing is captured well-enough-for-our-purposes in the "failure rate" metric).