### PR TITLE
Corchuelo recoverer

### DIFF
--- a/runner/build.sh
+++ b/runner/build.sh
@@ -94,6 +94,20 @@ if [ ! -f java_parser_panic ]; then
     cd ..
 fi
 
+if [ ! -f java_parser_corchuelo ]; then
+    cd grmtools
+    git reset --hard
+    patch -p0 < ../print_budget.patch
+    patch -p0 < ../dontmerge.patch
+    patch -p0 < ../corchuelo.patch
+    cd ../java_parser
+    sed -Ei "s/RecoveryKind::[a-zA-Z_]*[)]/RecoveryKind::CPCTPlus)/" build.rs
+    rm -rf target
+    cargo build --release
+    cp target/release/java_parser ../java_parser_corchuelo
+    cd ..
+fi
+
 if [ ! -d pykalibera ]; then
     git clone https://github.com/softdevteam/libkalibera/
     mv libkalibera/python/pykalibera pykalibera

--- a/runner/corchuelo.patch
+++ b/runner/corchuelo.patch
@@ -1,0 +1,261 @@
+diff --git lrpar/src/lib/astar.rs lrpar/src/lib/astar.rs
+index b4b77c2..981d35f 100644
+--- lrpar/src/lib/astar.rs
++++ lrpar/src/lib/astar.rs
+@@ -1,4 +1,4 @@
+-use std::{fmt::Debug, hash::Hash};
++use std::{collections::VecDeque, fmt::Debug, hash::Hash};
+ 
+ use indexmap::{
+     indexmap,
+@@ -146,71 +146,23 @@ where
+     FM: Fn(&mut N, N),
+     FS: Fn(&N) -> bool
+ {
+-    let mut scs_nodes = Vec::new();
+-    let mut todo: Vec<IndexMap<N, N>> = vec![indexmap![start_node.clone() => start_node]];
+-    let mut c: u16 = 0;
++    let mut todo = VecDeque::new();
++    todo.push_front((0, start_node.clone()));
+     let mut next = Vec::new();
+-    loop {
+-        if todo[usize::from(c)].is_empty() {
+-            c = c.checked_add(1).unwrap();
+-            if usize::from(c) == todo.len() {
+-                return Vec::new();
+-            }
+-            continue;
+-        }
+-
+-        let n = todo[usize::from(c)].pop().unwrap().1;
+-        if success(&n) {
+-            scs_nodes.push(n);
+-            break;
+-        }
++    while !todo.is_empty() {
++        let (c, n) = todo.pop_front().unwrap();
+ 
+         if !neighbours(true, &n, &mut next) {
+             return Vec::new();
+         }
+         for (nbr_cost, nbr) in next.drain(..) {
+-            let off = usize::from(nbr_cost);
+-            for _ in todo.len()..off + 1 {
+-                todo.push(IndexMap::new());
+-            }
+-            match todo[off].entry(nbr.clone()) {
+-                Entry::Vacant(e) => {
+-                    e.insert(nbr);
+-                }
+-                Entry::Occupied(mut e) => {
+-                    merge(&mut e.get_mut(), nbr);
+-                }
++            if success(&nbr) {
++                println!("repair cost {}", c);
++                return vec![nbr];
+             }
++
++            todo.push_back((nbr_cost, nbr));
+         }
+     }
+-
+-    let mut scs_todo = todo
+-        .drain(usize::from(c)..usize::from(c) + 1)
+-        .nth(0)
+-        .unwrap();
+-    while !scs_todo.is_empty() {
+-        let n = scs_todo.pop().unwrap().1;
+-        if success(&n) {
+-            scs_nodes.push(n);
+-            continue;
+-        }
+-        if !neighbours(false, &n, &mut next) {
+-            return Vec::new();
+-        }
+-        for (nbr_cost, nbr) in next.drain(..) {
+-            if nbr_cost == c {
+-                match scs_todo.entry(nbr.clone()) {
+-                    Entry::Vacant(e) => {
+-                        e.insert(nbr);
+-                    }
+-                    Entry::Occupied(mut e) => {
+-                        merge(&mut e.get_mut(), nbr);
+-                    }
+-                }
+-            }
+-        }
+-    }
+-
+-    println!("repair cost {}", c);
+-    scs_nodes
++    Vec::new()
+ }
+diff --git lrpar/src/lib/cpctplus.rs lrpar/src/lib/cpctplus.rs
+index cd8ba29..caa0b1d 100644
+--- lrpar/src/lib/cpctplus.rs
++++ lrpar/src/lib/cpctplus.rs
+@@ -13,11 +13,15 @@ use super::{
+     astar::dijkstra,
+     lex::Lexeme,
+     mf::{apply_repairs, rank_cnds, simplify_repairs},
++    panic,
+     parser::{AStackType, ParseRepair, Parser, Recoverer},
+     Span
+ };
+ 
+ const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
++const MAX_DELETES: usize = 3; // Nd in Corchuelo et al.
++const MAX_INSERTS: usize = 4; // Ni in Corchuelo et al.
++const MAX_INPUT: usize = 10; // Nt in Corchuelo et al.
+ 
+ #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+ enum Repair<StorageT> {
+@@ -138,6 +142,9 @@ where
+                 if Instant::now() >= finish_by {
+                     return false;
+                 }
++                if n.laidx >= in_laidx + MAX_INPUT {
++                    return true;
++                }
+ 
+                 match n.last_repair() {
+                     Some(Repair::Delete) => {
+@@ -194,26 +201,27 @@ where
+             }
+         );
+ 
+-        if astar_cnds.is_empty() {
+-            return (in_laidx, vec![]);
+-        }
+-
+         let full_rprs = self.collect_repairs(in_laidx, astar_cnds);
+-        let mut rnk_rprs = rank_cnds(parser, finish_by, in_laidx, &in_pstack, full_rprs);
+-        if rnk_rprs.is_empty() {
+-            return (in_laidx, vec![]);
+-        }
+-        simplify_repairs(parser, &mut rnk_rprs);
+-        let laidx = apply_repairs(
+-            parser,
+-            in_laidx,
+-            &mut in_pstack,
+-            &mut Some(&mut astack),
+-            &mut Some(&mut spans),
+-            &rnk_rprs[0]
+-        );
++        if full_rprs.len() == 0 {
++            panic::recoverer(parser).recover(finish_by, parser, in_laidx, in_pstack, astack, spans)
++        } else {
++            let mut rnk_rprs = rank_cnds(parser, finish_by, in_laidx, &in_pstack, full_rprs);
++            assert!(rnk_rprs.len() < 2);
++            if rnk_rprs.is_empty() {
++                return (in_laidx, vec![]);
++            }
++            simplify_repairs(parser, &mut rnk_rprs);
++            let laidx = apply_repairs(
++                parser,
++                in_laidx,
++                &mut in_pstack,
++                &mut Some(&mut astack),
++                &mut Some(&mut spans),
++                &rnk_rprs[0]
++            );
+ 
+-        (laidx, rnk_rprs)
++            (laidx, rnk_rprs)
++        }
+     }
+ }
+ 
+@@ -229,6 +237,16 @@ where
+     u32: AsPrimitive<StorageT>
+ {
+     fn insert(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, PathFNode<StorageT>)>) {
++        let num_inserts = n.repairs.vals().filter(|x| {
++            match *x {
++                RepairMerge::Repair(Repair::InsertTerm(_)) | RepairMerge::Merge(Repair::InsertTerm(_), _) => true,
++                _ => false
++            }
++        }).count();
++        if num_inserts == MAX_INSERTS {
++            return;
++        }
++
+         let laidx = n.laidx;
+         for tidx in self.parser.stable.state_actions(*n.pstack.val().unwrap()) {
+             if tidx == self.parser.grm.eof_token_idx() {
+@@ -270,6 +288,16 @@ where
+             return;
+         }
+ 
++        let num_deletes = n.repairs.vals().filter(|x| {
++            match *x {
++                RepairMerge::Repair(Repair::Delete) | RepairMerge::Merge(Repair::Delete, _) => true,
++                _ => false
++            }
++        }).count();
++        if num_deletes == MAX_DELETES {
++            return;
++        }
++
+         let la_tidx = self.parser.next_tidx(n.laidx);
+         let cost = (self.parser.token_cost)(la_tidx);
+         let nn = PathFNode {
+@@ -284,37 +312,21 @@ where
+     fn shift(&self, n: &PathFNode<StorageT>, nbrs: &mut Vec<(u16, PathFNode<StorageT>)>) {
+         // Forward move rule (ER3)
+         //
+-        // Note the rule in Corchuelo et al. is confusing and, I think, wrong. It reads:
++        // Note the rule in Corchuelo et al. is confusing. It reads:
+         //   (S, I) \rightarrow_{LR*} (S', I')
+         //   \wedge (j = N \vee 0 < j < N \wedge f(q_r, t_{j + 1} \in {accept, error})
+-        // First I think the bracketing would be clearer if written as:
++        // I think the bracketing would be clearer if written as:
+         //   j = N \vee (0 < j < N \wedge f(q_r, t_{j + 1} \in {accept, error})
+-        // And I think the condition should be:
+-        //   j = N \vee (0 <= j < N \wedge f(q_r, t_{j + 1} \in {accept, error})
+-        // because there's no reason that any symbols need to be shifted in order for an accept
+-        // (or, indeed an error) state to be reached.
+-        //
+-        // So the full rule should, I think, be:
+-        //   (S, I) \rightarrow_{LR*} (S', I')
+-        //   \wedge (j = N \vee (0 <= j < N \wedge f(q_r, t_{j + 1} \in {accept, error}))
+-        //
+-        // That said, as KimYi somewhat obliquely mention, generating multiple shifts in one go is
+-        // a bad idea: it means that we miss out on some minimal cost repairs. Instead, we should
+-        // only generate one shift at a time. So the adjusted rule we implement is:
+-        //
+-        //   (S, I) \rightarrow_{LR*} (S', I')
+-        //   \wedge 0 <= j < 1 \wedge S != S'
+ 
+         let laidx = n.laidx;
+         let (new_laidx, n_pstack) =
+             self.parser
+-                .lr_cactus(None, laidx, laidx + 1, n.pstack.clone(), &mut None);
+-        if n.pstack != n_pstack {
+-            let n_repairs = if new_laidx > laidx {
+-                n.repairs.child(RepairMerge::Repair(Repair::Shift))
+-            } else {
+-                n.repairs.clone()
+-            };
++                .lr_cactus(None, laidx, laidx + PARSE_AT_LEAST, n.pstack.clone(), &mut None);
++        if new_laidx > laidx || (new_laidx == laidx + PARSE_AT_LEAST && self.parser.stable.action(*n_pstack.val().unwrap(), self.parser.next_tidx(new_laidx)) == Action::Accept) {
++            let mut n_repairs = n.repairs.clone();
++            for _ in laidx..new_laidx {
++                n_repairs = n.repairs.child(RepairMerge::Repair(Repair::Shift));
++            }
+             let nn = PathFNode {
+                 pstack: n_pstack,
+                 laidx: new_laidx,
+diff --git lrpar/src/lib/ctbuilder.rs lrpar/src/lib/ctbuilder.rs
+index 3ac7e54..fda3115 100644
+--- lrpar/src/lib/ctbuilder.rs
++++ lrpar/src/lib/ctbuilder.rs
+@@ -154,7 +154,7 @@ where
+     pub fn new_with_storaget() -> Self {
+         CTParserBuilder {
+             mod_name: None,
+-            recoverer: RecoveryKind::MF,
++            recoverer: RecoveryKind::CPCTPlus,
+             yacckind: None,
+             error_on_conflicts: true,
+             conflicts: None,

--- a/runner/process.py
+++ b/runner/process.py
@@ -192,8 +192,8 @@ def process(latex_name, p):
                 assert s[3] == "0"
                 succeeded = False
             costs = [int(x) for x in s[5].split(":") if x != ""]
-            if latex_name != "\\panic" and succeeded and len(costs) == 0:
-                print "Warning: %s (pexec #%s) succeeded without parsing errors" % (s[0], s[1])
+            if latex_name not in ["\\corchuelo", "\\panic"] and succeeded and len(costs) == 0:
+                print "Warning: %s (pexec #%s of %s) succeeded without parsing errors" % (s[0], s[1], latex_name)
                 continue
             pexec = PExec(s[0], int(s[1]), float(s[2]), succeeded, int(s[4]), costs, int(s[6]), int(s[7]))
             max_run_num = max(max_run_num, pexec.run_num)
@@ -407,6 +407,12 @@ with open("experimentstats.tex", "w") as f:
     cpctpluslonger.bootstrapped_recovery_means = None
     cpctpluslonger.bootstrapped_error_locs = None
 
+    corchuelo = process("\\corchuelo", "corchuelo.csv")
+    assert cpctplus.num_runs == corchuelo.num_runs
+
+    corchuelo.bootstrapped_recovery_means = None
+    corchuelo.bootstrapped_error_locs = None
+
     panic = process("\\panic", "panic.csv")
     assert cpctplus.num_runs == cpctplusrev.num_runs == panic.num_runs
     panic_cpctplus_ratio_ci = confidence_ratio_error_locs(panic, cpctplus)
@@ -446,17 +452,16 @@ with open("experimentstats.tex", "w") as f:
         f.write("\n")
 
 with open("table.tex", "w") as f:
-    for x in [panic, cpctplus, cpctplusdontmerge, cpctplusrev]:
-        if x.latex_name == "\\panic":
+    for x in [corchuelo, cpctplus, panic, cpctplusdontmerge, cpctplusrev]:
+        if x.latex_name in ["\\corchuelo", "\\panic"]:
             costs_median = "-"
             costs_ci = ""
-            failure_rate_median = "-"
-            failure_rate_ci = ""
         else:
             costs_median = "%.2f" % x.costs_ci.median
             costs_ci = "{\scriptsize$\pm$%s}" % ci_pp(x.costs_ci.error, 3)
-            failure_rate_median = "%.2f" % x.failure_rate_ci.median
-            failure_rate_ci = "{\scriptsize$\pm$%s}" % ci_pp(x.failure_rate_ci.error, 3)
+        failure_rate_median = "%.2f" % x.failure_rate_ci.median
+        failure_rate_ci = "{\scriptsize$\pm$%s}" % ci_pp(x.failure_rate_ci.error, 3)
+
         f.write("%s & %.6f & %.6f & %s & %s & %.2f & \\numprint{%d} \\\\[-4pt]\n" % \
                 (x.latex_name, \
                  x.recovery_time_mean_ci.median, \

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -10,5 +10,7 @@ echo "===> cpctplus_rev"
 ./run.py ../blackbox/src_files ./java_parser_cpctplus_rev 0.5 cpctplus_rev.csv
 echo "===> cpctplus_long"
 ./run.py ../blackbox/src_files ./java_parser_cpctplus_longer 2.0 cpctplus_longer.csv
+echo "===> corchuelo"
+./run.py ../blackbox/src_files ./java_parser_corchuelo 0.5 corchuelo.csv
 echo "===> panic"
 ./run.py ../blackbox/src_files ./java_parser_panic 0.5 panic.csv


### PR DESCRIPTION
Needs #31 to be merged first.

This PR adds a diff which turns CPCT+ back into a semi-faithful recreation of Corchuelo et al.'s original algorithm. At a high level this requires changes to `cpctplus.rs` and the queue algorithm (which is still called `dijkstra`, even though it isn't!).

In more detail, it: turns off merging; changes the shift rule to CR Shift 1; implement the fixed limits they have (any given repair sequence can have at most 3 deletes and 4 inserts and can't span more than 10 tokens of the user's input); finish recovery as soon as the first success node is found; and finally, if recovery fails (within the time limit!), falls back on panic mode.