### PR TITLE
Include unsuccessful pexecs in the costs calculation.

### DIFF
--- a/runner/process.py
+++ b/runner/process.py
@@ -132,10 +132,8 @@ class Results:
             costs = []
             for pexecs in self.pexecs:
                 pexec = random.choice(pexecs)
-                if pexec.succeeded:
-                    costs.extend(pexec.costs)
-            if len(costs) > 0:
-                out.append(mean(costs))
+                costs.extend(pexec.costs)
+            out.append(mean(costs))
         return out
 
     def bootstrap_input_skipped(self):


### PR DESCRIPTION
This puts it in line with our other calculations -- I'm not really sure why I ever thought excluding unsuccessful pexecs was a good idea. Also, in practise, it makes almost no difference to the eventual calculation.